### PR TITLE
Fixed RabbitMQ bug

### DIFF
--- a/lib/roomtrol/device.rb
+++ b/lib/roomtrol/device.rb
@@ -751,10 +751,12 @@ module Wescontrol
 			message[:update] = true
 			message[:severity] ||= 0.1
 			message[:time] ||= Time.now.to_i
-			MQ.new.topic(EVENT_TOPIC).publish(
+	    amq = MQ.new
+			amq.topic(EVENT_TOPIC).publish(
 				message.to_json,
         :key => "device.#{@name}"
 			) if @amq_responder
+		  amq.close
 		end
 		
 		# Saves the current state of the device to CouchDB and sends updates on the update queue

--- a/lib/roomtrol/wescontrol_http.rb
+++ b/lib/roomtrol/wescontrol_http.rb
@@ -36,6 +36,7 @@ module Wescontrol
     end
     
     def unbind
+      @amq.close
       @queue.unsubscribe
     end
     


### PR DESCRIPTION
RabbitMQ was going down after a couple of weeks because every few seconds wescontrol_http creates a channel that is never closed. as far as i know roomtrolDaemonChecker in Zenoss is the only thing that connects to wescontrol_http every few seconds...so ironically, Zenoss was taking down Roomtrol. Sigh.

Also, devices.rb was creating a new channel on every event.
